### PR TITLE
Move ccurl submodule from root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ccurl"]
-	path = ccurl
+[submodule "ccurl_repo/ccurl"]
+	path = ccurl_repo/ccurl
 	url = https://github.com/iotaledger/ccurl.git

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# ccurl submodule can't be at root level, because then naming collides with
+# pyota-ccurl's naming in iota.py repo.
+# In iota.crypto.__init__, `from ccurl import ...` tries to import
+# from this `ccurl` rather then from `pyota-ccurl`, that results in ImportError.
+
 # Updating ccurl submodule
 git submodule update --init --recursive
 # Delete binaries if present
@@ -10,9 +15,9 @@ WD=$(pwd)
 
 # Bulding using cmake
 echo "Building ccurl library with cmake..."
-cd ccurl && mkdir -p build && cd build && cmake .. && cmake --build .
-cd ../..
-LIB=$(find . -name "*.so")
+cd ccurl_repo/ccurl && mkdir -p build && cd build && cmake .. && cmake --build .
+cd ../../..
+LIB=$(find ./ccurl_repo -name "*.so")
 
 echo "The built library is at:"
 echo $LIB

--- a/pow/ccurl_interface.py
+++ b/pow/ccurl_interface.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from ctypes import *
-from iota import TransactionTrytes, Bundle, TryteString, TransactionHash, Transaction
-from iota.exceptions import with_context
+from iota import Bundle, TransactionTrytes, TransactionHash, TryteString, \
+    Transaction
 import math
 import time
+from iota.exceptions import with_context
 
 from pkg_resources import resource_filename
 libccurl_path = resource_filename("pow","libccurl.so")


### PR DESCRIPTION
Having it at root level results in name collision
with iota.py and ImportError. Moving it one level deeper.